### PR TITLE
Fix /reply displaying incorrect recipient

### DIFF
--- a/src/main/java/com/dinnerbone/bukkit/chat/commands/ReplyCommand.java
+++ b/src/main/java/com/dinnerbone/bukkit/chat/commands/ReplyCommand.java
@@ -32,7 +32,7 @@ public class ReplyCommand extends CommandHandler {
             // TODO: This should use an event, but we need some internal changes to support that fully.
 
             if (target instanceof Player) {
-                name = ((Player)sender).getDisplayName();
+                name = ((Player)target).getDisplayName();
             }
             
             target.sendMessage(String.format("[%s]->[you]: %s", player.getDisplayName(), message));


### PR DESCRIPTION
When the /reply command is used, the reply is sent to the correct recipient, but the sender is informed that the message was sent to himself.
